### PR TITLE
refactor: JwtTokenFilter를 빈으로 등록하여 필터를 중복하여 추가하지 않도록 한다.

### DIFF
--- a/src/main/java/com/jooany/letsdeal/config/filter/JwtTokenFilter.java
+++ b/src/main/java/com/jooany/letsdeal/config/filter/JwtTokenFilter.java
@@ -1,115 +1,122 @@
 package com.jooany.letsdeal.config.filter;
 
+import java.io.IOException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.jooany.letsdeal.config.JwtTokenConfig;
 import com.jooany.letsdeal.controller.dto.UserDto;
 import com.jooany.letsdeal.repository.redis.RefreshTokenRepository;
 import com.jooany.letsdeal.service.UserService;
 import com.jooany.letsdeal.util.JwtTokenUtils;
+
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 @Slf4j
-@Component
-@RequiredArgsConstructor
 public class JwtTokenFilter extends OncePerRequestFilter {
-    private static final String AUTH_HEADER_PREFIX = "Bearer ";
-    private static final String REFRESH_HEADER = "X-Refresh-Token";
+	private static final String AUTH_HEADER_PREFIX = "Bearer ";
+	private static final String REFRESH_HEADER = "X-Refresh-Token";
+	private JwtTokenConfig jwtTokenConfig;
+	private UserService userService;
+	private RefreshTokenRepository refreshTokenRepository;
 
-    private final JwtTokenConfig jwtTokenConfig;
-    private final UserService userService;
-    private final RefreshTokenRepository refreshTokenRepository;
+	public JwtTokenFilter(
+		JwtTokenConfig jwtTokenConfig,
+		UserService userService,
+		RefreshTokenRepository refreshTokenRepository
+	) {
+		this.jwtTokenConfig = jwtTokenConfig;
+		this.userService = userService;
+		this.refreshTokenRepository = refreshTokenRepository;
+	}
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
 
-        final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+		final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+		if (authHeader == null || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 
-        final String accessToken = extractToken(authHeader);
-        if (accessToken.isBlank()) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+		final String accessToken = extractToken(authHeader);
+		if (accessToken.isBlank()) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 
-        try {
-            if (isRefreshRequest(request)) {
-                String refreshToken = request.getHeader(REFRESH_HEADER);
-                handleRefreshToken(request, refreshToken, jwtTokenConfig.getRefreshTokenSecretKey());
-            } else {
-                handleAccessToken(request, accessToken, jwtTokenConfig.getAccessTokenSecretKey());
-            }
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("JWT 검증 실패: {}", e.getMessage());
-            filterChain.doFilter(request, response);
-            return;
-        }
+		try {
+			if (isRefreshRequest(request)) {
+				String refreshToken = request.getHeader(REFRESH_HEADER);
+				handleRefreshToken(request, refreshToken, jwtTokenConfig.getRefreshTokenSecretKey());
+			} else {
+				handleAccessToken(request, accessToken, jwtTokenConfig.getAccessTokenSecretKey());
+			}
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("JWT 검증 실패: {}", e.getMessage());
+			filterChain.doFilter(request, response);
+			return;
+		}
 
-        filterChain.doFilter(request, response);
-    }
+		filterChain.doFilter(request, response);
+	}
 
-    private void handleAccessToken(HttpServletRequest request, String token, String accessTokenSecretKey) {
-        if (JwtTokenUtils.isExpired(token, accessTokenSecretKey)) {
-            throw new JwtException("Access Token 만료");
-        }
+	private void handleAccessToken(HttpServletRequest request, String token, String accessTokenSecretKey) {
+		if (JwtTokenUtils.isExpired(token, accessTokenSecretKey)) {
+			throw new JwtException("Access Token 만료");
+		}
 
-        String username = JwtTokenUtils.getUserName(token, accessTokenSecretKey);
-        authenticateUser(request, username);
-    }
+		String username = JwtTokenUtils.getUserName(token, accessTokenSecretKey);
+		authenticateUser(request, username);
+	}
 
-    private void handleRefreshToken(HttpServletRequest request, String refreshToken, String refreshTokenSecretKey) {
-        if (refreshToken == null || refreshToken.isBlank()) {
-            throw new JwtException("Refresh Token 없음");
-        }
+	private void handleRefreshToken(HttpServletRequest request, String refreshToken, String refreshTokenSecretKey) {
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw new JwtException("Refresh Token 없음");
+		}
 
-        if (JwtTokenUtils.isExpired(refreshToken, refreshTokenSecretKey)) {
-            throw new JwtException("Refresh Token 만료");
-        }
+		if (JwtTokenUtils.isExpired(refreshToken, refreshTokenSecretKey)) {
+			throw new JwtException("Refresh Token 만료");
+		}
 
-        String username = JwtTokenUtils.getUserName(refreshToken, refreshTokenSecretKey);
-        String storedToken = refreshTokenRepository.getRefreshToken(username).orElse("");
+		String username = JwtTokenUtils.getUserName(refreshToken, refreshTokenSecretKey);
+		String storedToken = refreshTokenRepository.getRefreshToken(username).orElse("");
 
-        if (!refreshToken.equals(storedToken)) {
-            throw new JwtException("Refresh Token 불일치");
-        }
+		if (!refreshToken.equals(storedToken)) {
+			throw new JwtException("Refresh Token 불일치");
+		}
 
-        authenticateUser(request, username);
-        request.setAttribute("userName", username);
-    }
+		authenticateUser(request, username);
+		request.setAttribute("userName", username);
+	}
 
-    private void authenticateUser(HttpServletRequest request, String username) {
-        UserDto userDto = userService.loadUserByUserName(username);
-        userDto.setNullPassword();
+	private void authenticateUser(HttpServletRequest request, String username) {
+		UserDto userDto = userService.loadUserByUserName(username);
+		userDto.setNullPassword();
 
-        UsernamePasswordAuthenticationToken authToken =
-                new UsernamePasswordAuthenticationToken(userDto, null, userDto.getAuthorities());
+		UsernamePasswordAuthenticationToken authToken =
+			new UsernamePasswordAuthenticationToken(userDto, null, userDto.getAuthorities());
 
-        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-    }
+		authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+		SecurityContextHolder.getContext().setAuthentication(authToken);
+	}
 
-    private boolean isRefreshRequest(HttpServletRequest request) {
-        return "/api/v1/users/tokens".equals(request.getRequestURI());
-    }
+	private boolean isRefreshRequest(HttpServletRequest request) {
+		return "/api/v1/users/tokens".equals(request.getRequestURI());
+	}
 
-    private String extractToken(String header) {
-        return header.substring(AUTH_HEADER_PREFIX.length()).trim();
-    }
+	private String extractToken(String header) {
+		return header.substring(AUTH_HEADER_PREFIX.length()).trim();
+	}
 }

--- a/src/main/java/com/jooany/letsdeal/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/jooany/letsdeal/exception/CustomAuthenticationEntryPoint.java
@@ -1,33 +1,35 @@
 package com.jooany.letsdeal.exception;
 
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
 import com.jooany.letsdeal.controller.dto.response.Response;
 import com.jooany.letsdeal.util.JsonUtils;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
-
-import java.io.IOException;
 
 @RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
-    private final JsonUtils jsonUtils;
+	private final JsonUtils jsonUtils;
 
-    @Override
-    public void commence(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            AuthenticationException authException
-    ) throws IOException, ServletException {
-        response.setContentType("application/json; charset=UTF-8");
-        response.setStatus(ErrorCode.INVALID_TOKEN.getStatus().value());
-        response.getWriter()
-                .write(
-                        jsonUtils.toJson(
-                                Response.error(ErrorCode.INVALID_TOKEN.name(), ErrorCode.INVALID_TOKEN.getMessage())
-                        )
-                );
-    }
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException, ServletException {
+		response.setContentType("application/json; charset=UTF-8");
+		response.setStatus(ErrorCode.INVALID_TOKEN.getStatus().value());
+		response.getWriter()
+			.write(
+				jsonUtils.toJson(
+					Response.error(ErrorCode.INVALID_TOKEN.name(), ErrorCode.INVALID_TOKEN.getMessage())
+				)
+			);
+	}
 }


### PR DESCRIPTION
JwtTokenFilter를 @component 로 선언하면 servlet filter에 자동으로 추가된다.
시큐리티의 필터체인에서도 추가를 해주었기 때문에 해당 필터가 두 번 호출되는 이슈가 있어, 이를 방지하도록 빈으로 따로 정의하여 사용한다.